### PR TITLE
16 - Node version to 20.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/huridocs/react-text-selection-handler.git"
   },
   "engines": {
-    "node": ">=20.12.0",
+    "node": ">=20.9.0",
     "npm": ">=9"
   },
   "publishConfig": {


### PR DESCRIPTION
The official version of Uwazi at the current date is 20.9, downgrading the package version for compatibility 